### PR TITLE
Merge output after build with ILMerge

### DIFF
--- a/DeltaStepsBetweenEnvironments/DeltaStepsBetweenEnvironments.csproj
+++ b/DeltaStepsBetweenEnvironments/DeltaStepsBetweenEnvironments.csproj
@@ -182,4 +182,16 @@
   move /Y Carfup.XTBPlugins.*.pdb Plugins
 )</PostBuildEvent>
   </PropertyGroup>
+  <Target Name="AfterBuild" Condition="'$(Configuration)' == 'Release'">
+    <ItemGroup>
+      <MergeAssemblies Include="$(OutputPath)\Carfup.XTBPlugins.DeltaStepsBetweenEnvironments.dll" />
+      <MergeAssemblies Include="$(OutputPath)\Microsoft.ApplicationInsights.dll" />
+    </ItemGroup>
+    <PropertyGroup>
+      <OutputAssembly>$(OutputPath)Merged\Carfup.XTBPlugins.DeltaStepsBetweenEnvironments.dll</OutputAssembly>
+    </PropertyGroup>
+    <MakeDir Directories="$(OutputPath)Merged" />
+    <Message Text="MERGING: @(MergeAssemblies->'%(Filename)') into $(OutputAssembly)" Importance="High" />
+    <Exec Command="ilmerge /out:&quot;$(OutputAssembly)&quot; @(MergeAssemblies->'&quot;%(FullPath)&quot;', ' ')" />
+  </Target>   
 </Project>

--- a/DeltaStepsBetweenEnvironments/DeltaStepsBetweenEnvironments.nuspec
+++ b/DeltaStepsBetweenEnvironments/DeltaStepsBetweenEnvironments.nuspec
@@ -35,7 +35,6 @@ Find out if there is differences about your plugin steps between two of your env
     </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\Carfup.XTBPlugins.*.dll" target="lib\net462\Plugins" />
-	<file src="bin\Release\Microsoft.ApplicationInsights.dll" target="lib\net46\Plugins" />
+    <file src="bin\Release\Merged\Carfup.XTBPlugins.*.dll" target="lib\net462\Plugins" />
   </files>
 </package>

--- a/DeltaStepsBetweenEnvironments/packages.config
+++ b/DeltaStepsBetweenEnvironments/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="ILMerge.Tools" version="2.14.1208" targetFramework="net462" />
   <package id="Microsoft.ApplicationInsights" version="2.4.0" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" targetFramework="net462" />


### PR DESCRIPTION
Added Reference to ILMerge.Tools
extended csproj to merge Assembly after build into "Merged" folder
update the nuspec file to reference the new merged output and removed the Insights link.

If build fails, make sure, you have the Package Manager Console open and initialized.